### PR TITLE
Fix Databricks ResultSet error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 config ?= compileClasspath
+version ?= $(shell grep 'Plugin-Version' plugins/nf-sqldb/src/resources/META-INF/MANIFEST.MF | awk '{ print $$2 }')
 
 ifdef module 
 mm = :${module}:
@@ -69,3 +70,9 @@ upload-plugins:
 
 publish-index:
 	./gradlew plugins:publishIndex
+
+# Install the plugin into local nextflow plugins dir
+install:
+	./gradlew copyPluginZip
+	rm -rf ${HOME}/.nextflow/plugins/nf-sqldb-${version}
+	cp -r build/plugins/nf-sqldb-${version} ${HOME}/.nextflow/plugins/nf-sqldb-${version}

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -47,7 +47,8 @@ class ChannelSqlExtension extends PluginExtensionPoint {
             db: CharSequence,
             emitColumns: Boolean,
             batchSize: Integer,
-            batchDelay: Integer
+            batchDelay: Integer,
+            executeUpdate: Boolean
     ]
 
     private static final Map INSERT_PARAMS = [

--- a/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
@@ -71,6 +71,7 @@ class QueryHandler implements QueryOp<QueryHandler> {
     private Integer batchSize
     private long batchDelayMillis = 100
     private int queryCount
+    private boolean executeUpdate = false
 
     @Override
     QueryOp withStatement(String stm) {
@@ -97,6 +98,8 @@ class QueryHandler implements QueryOp<QueryHandler> {
             this.batchSize = opts.batchSize as Integer
         if( opts.batchDelay )
             this.batchDelayMillis = opts.batchDelay as long
+        if( opts.executeUpdate )
+            this.executeUpdate = opts.executeUpdate as boolean
         return this
     }
 
@@ -156,10 +159,29 @@ class QueryHandler implements QueryOp<QueryHandler> {
     protected void query0(Connection conn) {
         try {
             try (Statement stm = conn.createStatement()) {
-                try( def rs = stm.executeQuery(normalize(statement)) ) {
-                    if( emitColumns )
-                        emitColumns(rs)
-                    emitRowsAndClose(rs)
+                final String normalizedStmt = normalize(statement)
+                // Check if statement is a DDL or UPDATE statement that doesn't return a ResultSet
+                boolean isUpdateOrDdl = executeUpdate || 
+                                       normalizedStmt.toUpperCase().startsWith("CREATE ") || 
+                                       normalizedStmt.toUpperCase().startsWith("ALTER ") || 
+                                       normalizedStmt.toUpperCase().startsWith("DROP ") || 
+                                       normalizedStmt.toUpperCase().startsWith("INSERT ") ||
+                                       normalizedStmt.toUpperCase().startsWith("UPDATE ") ||
+                                       normalizedStmt.toUpperCase().startsWith("DELETE ");
+                
+                if (isUpdateOrDdl) {
+                    // Use executeUpdate for statements that don't return ResultSets
+                    stm.executeUpdate(normalizedStmt)
+                    // Since there's no ResultSet to emit, just close the channel
+                    target.bind(Channel.STOP)
+                } 
+                else {
+                    // For SELECT and other queries that return ResultSets
+                    try (def rs = stm.executeQuery(normalizedStmt)) {
+                        if (emitColumns)
+                            emitColumns(rs)
+                        emitRowsAndClose(rs)
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
ResultSet was expected but not generated from query: INSERT INTO ap_demo.nextflowtest.table1
```

The problem is in the QueryHandler class. When executing a DDL statement like CREATE TABLE, the code is using executeQuery(), which expects a ResultSet to be returned. However, DDL statements don't return ResultSets; they should use executeUpdate() instead.