### PR TITLE
Fix default credentials being used if secrets aren't resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The following options are available:
 `sql.db.'<DB-NAME>'.password`
 : The database connection password.
 
+For information on using secrets with database credentials, see [docs/secrets.md](docs/secrets.md).
+
 ## Dataflow Operators
 
 This plugin provides the following dataflow operators for querying from and inserting into database tables.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 NF-SQLDB CHANGE-LOG
 ===================
+0.7.1 - 21 Aug 2025
+- Fix unresolved secrets detection to prevent silent fallback to default credentials
+- Add comprehensive secrets documentation and troubleshooting guide
+- Improve error messages for unknown database configurations
+
 0.7.0 - 28 May 2025
 - Add sqlExecutor and other minor improvements [072ae039]
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,55 @@
+# Using Secrets for Database Credentials
+
+For production deployments, it's recommended to use Nextflow secrets instead of hardcoding credentials in configuration files. This is especially important when working with cloud databases like AWS Athena.
+
+## Configuration with Secrets
+
+When using [Nextflow secrets](https://www.nextflow.io/docs/latest/secrets.html) (available in Nextflow 25.04.0+), you can reference workspace or user-level secrets in your database configuration:
+
+```groovy
+sql {
+    db {
+        athena {
+            url = 'jdbc:awsathena://AwsRegion=us-east-1;S3OutputLocation=s3://bucket;Workgroup=workgroup'
+            user = secrets.ATHENA_USER
+            password = secrets.ATHENA_PASSWORD
+            driver = 'com.simba.athena.jdbc.Driver'
+        }
+    }
+}
+```
+
+## Setting Up Secrets in Seqera Platform
+
+1. **Workspace Secrets**: Navigate to your workspace → Secrets → Add secret
+2. **User Secrets**: Navigate to Your profile → Secrets → Add secret  
+3. Create secrets with names matching your configuration (e.g., `ATHENA_USER`, `ATHENA_PASSWORD`)
+
+## Troubleshooting Secrets Issues
+
+If you encounter authentication errors like "Missing credentials error", verify:
+
+- **Secret Names**: Ensure secret names in your configuration match exactly (case-sensitive)
+- **Permissions**: Verify you have access to workspace secrets or have defined user-level secrets
+- **Nextflow Version**: Secrets require Nextflow >=25.04.0
+- **Secret Values**: Ensure secrets contain valid credentials (no empty values)
+
+Common error patterns:
+- `user=sa; password=null` indicates secrets were not resolved
+- `Unresolved secret detected` means secret names don't match or aren't accessible
+
+## Local Development
+
+For local testing, you can use the Nextflow secrets command:
+
+```bash
+# Set secrets locally
+nextflow secrets set ATHENA_USER "your-username"  
+nextflow secrets set ATHENA_PASSWORD "your-password"
+
+# List secrets
+nextflow secrets list
+
+# Run pipeline with secrets
+nextflow run your-pipeline.nf
+```

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -106,11 +106,9 @@ class ChannelSqlExtension extends PluginExtensionPoint {
         final dataSource = config.getDataSource(dsName)
         if( dataSource==null ) {
             def msg = "Unknown db name: $dsName"
-            def choices = config.getDataSourceNames().closest(dsName) ?: config.getDataSourceNames()
-            if( choices?.size() == 1 )
-                msg += " - Did you mean: ${choices.get(0)}?"
-            else if( choices )
-                msg += " - Did you mean any of these?\n" + choices.collect { "  $it"}.join('\n') + '\n'
+            def choices = config.getDataSourceNames()
+            if( choices )
+                msg += " - Available databases: " + choices.join(', ')
             throw new IllegalArgumentException(msg)
         }
         return dataSource

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -43,19 +43,51 @@ class SqlDataSource {
     SqlDataSource(Map opts) {
         this.url = opts.url ?: DEFAULT_URL
         this.driver = opts.driver ?: urlToDriver(url) ?: DEFAULT_DRIVER
-        this.user = opts.user ?: DEFAULT_USER
-        this.password = opts.password
+        this.user = resolveCredential(opts.user, 'user') ?: DEFAULT_USER
+        this.password = resolveCredential(opts.password, 'password')
     }
 
     SqlDataSource(Map opts, SqlDataSource fallback) {
         this.url = opts.url ?: fallback.url ?: DEFAULT_URL
         this.driver = opts.driver ?: urlToDriver(url) ?: fallback.driver ?: DEFAULT_DRIVER
-        this.user = opts.user ?: fallback.user ?: DEFAULT_USER
-        this.password = opts.password ?: fallback.password
+        this.user = resolveCredential(opts.user, 'user') ?: fallback.user ?: DEFAULT_USER
+        this.password = resolveCredential(opts.password, 'password') ?: fallback.password
     }
 
     protected String urlToDriver(String url) {
         DriverRegistry.DEFAULT.urlToDriver(url)
+    }
+
+    /**
+     * Resolves a credential value, checking for unresolved secrets and providing appropriate error handling
+     * 
+     * @param value The credential value from configuration
+     * @param credType The type of credential ('user' or 'password') for error messages
+     * @return The resolved credential value, or null if not provided
+     * @throws IllegalArgumentException if an unresolved secret is detected
+     */
+    protected String resolveCredential(Object value, String credType) {
+        if (value == null) {
+            return null
+        }
+        
+        String stringValue = value.toString()
+        
+        // Check for unresolved secrets (patterns like 'secrets.ATHENA_USER' or similar)
+        if (stringValue.startsWith('secrets.') || stringValue.contains('secret') && stringValue.contains('[') && stringValue.contains(']')) {
+            throw new IllegalArgumentException(
+                "Unresolved secret detected for $credType: '$stringValue'. " +
+                "This typically indicates that workspace secrets are not properly configured or accessible. " +
+                "Please verify that:\n" +
+                "1. The secret is defined in your workspace/user secrets\n" +
+                "2. The secret name matches exactly (case-sensitive)\n" +
+                "3. You have proper permissions to access the secret\n" +
+                "4. The Nextflow version supports secrets integration (>=25.04.0)\n" +
+                "See: https://www.nextflow.io/docs/latest/secrets.html"
+            )
+        }
+        
+        return stringValue.isEmpty() ? null : stringValue
     }
 
     Map toMap() {

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -95,4 +95,42 @@ class ChannelSqlExtensionTest extends Specification {
         rows.alpha == ['x1','y2','z3']
     }
 
+    def 'should provide helpful error message for unresolved secrets' () {
+        given:
+        def session = Mock(Session) {
+            getConfig() >> [sql: [db: [athena: [
+                url: 'jdbc:awsathena://AwsRegion=us-east-1;S3OutputLocation=s3://bucket;Workgroup=CompBio',
+                user: 'secrets.ATHENA_USER',
+                password: '[secret]'
+            ]]]]
+        }
+        def sqlExtension = new ChannelSqlExtension()
+
+        when:
+        sqlExtension.init(session)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Unresolved secret detected")
+        e.message.contains("secrets.ATHENA_USER")
+        e.message.contains("workspace secrets are not properly configured")
+    }
+
+    def 'should handle unknown database' () {
+        given:
+        def session = Mock(Session) {
+            getConfig() >> [sql: [db: [default: [url: 'jdbc:h2:mem:'], postgres: [url: 'jdbc:postgresql:']]]]
+        }
+        def sqlExtension = new ChannelSqlExtension()
+        sqlExtension.init(session)
+
+        when:
+        sqlExtension.fromQuery([db: 'invalid'], 'select * from table')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Unknown db name: invalid")
+        e.message.contains("Available databases:")
+    }
+
 }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -95,25 +95,17 @@ class ChannelSqlExtensionTest extends Specification {
         rows.alpha == ['x1','y2','z3']
     }
 
-    def 'should provide helpful error message for unresolved secrets' () {
+    def 'should error on unresolved secrets' () {
         given:
         def session = Mock(Session) {
-            getConfig() >> [sql: [db: [athena: [
-                url: 'jdbc:awsathena://AwsRegion=us-east-1;S3OutputLocation=s3://bucket;Workgroup=CompBio',
-                user: 'secrets.ATHENA_USER',
-                password: '[secret]'
-            ]]]]
+            getConfig() >> [sql: [db: [test: [user: 'secrets.ATHENA_USER']]]]
         }
-        def sqlExtension = new ChannelSqlExtension()
 
         when:
-        sqlExtension.init(session)
+        new ChannelSqlExtension().init(session)
 
         then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains("Unresolved secret detected")
-        e.message.contains("secrets.ATHENA_USER")
-        e.message.contains("workspace secrets are not properly configured")
+        thrown(IllegalArgumentException)
     }
 
     def 'should handle unknown database' () {

--- a/plugins/nf-sqldb/src/test/nextflow/sql/SqlDslTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/SqlDslTest.groovy
@@ -209,6 +209,12 @@ class SqlDslTest extends Dsl2Spec {
     @Requires({System.getenv('NF_SQLDB_TEST_ATHENA_REGION')})
     @Requires({System.getenv('NF_SQLDB_ATHENA_TEST_S3_BUCKET')})
     @IgnoreIf({ System.getenv('NXF_SMOKE') })
+    @Requires({
+        System.getenv('NF_SQLDB_TEST_ATHENA_USERNAME') &&
+        System.getenv('NF_SQLDB_TEST_ATHENA_PASSWORD') &&
+        System.getenv('NF_SQLDB_TEST_ATHENA_REGION') &&
+        System.getenv('NF_SQLDB_ATHENA_TEST_S3_BUCKET')
+    })
     @Timeout(60)
     def 'should perform a query for AWS Athena and create a channel'() {
         given:

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -133,75 +133,23 @@ class SqlDataSourceTest extends Specification {
         ds1.hashCode() != ds3.hashCode()
     }
 
-    def 'should handle null credentials gracefully' () {
+    def 'should detect unresolved secrets' () {
         when:
-        def ds = new SqlDataSource([url: 'jdbc:h2:mem:', user: null, password: null])
-        then:
-        ds.user == SqlDataSource.DEFAULT_USER
-        ds.password == null
-    }
-
-    def 'should handle empty string credentials' () {
-        when:
-        def ds = new SqlDataSource([url: 'jdbc:h2:mem:', user: '', password: ''])
-        then:
-        ds.user == SqlDataSource.DEFAULT_USER
-        ds.password == null
-    }
-
-    def 'should detect unresolved secrets.* pattern' () {
-        when:
-        new SqlDataSource([user: 'secrets.ATHENA_USER'])
+        new SqlDataSource([user: pattern])
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains("Unresolved secret detected for user")
-        e.message.contains("secrets.ATHENA_USER")
+        e.message.contains("Unresolved secret detected")
         e.message.contains("workspace secrets are not properly configured")
+
+        where:
+        pattern << ['secrets.ATHENA_USER', '[secret]']
     }
 
-    def 'should detect unresolved [secret] pattern' () {
+    def 'should allow valid credentials' () {
         when:
-        new SqlDataSource([password: '[secret]'])
+        def ds = new SqlDataSource([user: 'validuser', password: 'validpass'])
         then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains("Unresolved secret detected for password")
-        e.message.contains("[secret]")
-        e.message.contains("workspace secrets are not properly configured")
-    }
-
-    def 'should allow valid secret-like strings that are not unresolved' () {
-        when:
-        def ds = new SqlDataSource([user: 'mysecret', password: 'secretpassword'])
-        then:
-        ds.user == 'mysecret'
-        ds.password == 'secretpassword'
-    }
-
-    def 'should handle secrets in fallback constructor' () {
-        given:
-        def fallback = new SqlDataSource([user: 'fallback_user', password: 'fallback_pass'])
-        
-        when:
-        new SqlDataSource([user: 'secrets.ATHENA_USER'], fallback)
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains("Unresolved secret detected for user")
-    }
-
-    def 'should provide comprehensive error message for secrets' () {
-        when:
-        new SqlDataSource([user: 'secrets.MISSING_SECRET'])
-        then:
-        def e = thrown(IllegalArgumentException)
-        with(e.message) {
-            contains("Unresolved secret detected")
-            contains("secrets.MISSING_SECRET")
-            contains("workspace secrets are not properly configured")
-            contains("secret is defined in your workspace")
-            contains("secret name matches exactly")
-            contains("proper permissions")
-            contains("Nextflow version supports secrets")
-            contains("https://www.nextflow.io/docs/latest/secrets.html")
-        }
+        ds.user == 'validuser'
+        ds.password == 'validpass'
     }
 }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -132,4 +132,76 @@ class SqlDataSourceTest extends Specification {
         ds1.hashCode() == ds2.hashCode()
         ds1.hashCode() != ds3.hashCode()
     }
+
+    def 'should handle null credentials gracefully' () {
+        when:
+        def ds = new SqlDataSource([url: 'jdbc:h2:mem:', user: null, password: null])
+        then:
+        ds.user == SqlDataSource.DEFAULT_USER
+        ds.password == null
+    }
+
+    def 'should handle empty string credentials' () {
+        when:
+        def ds = new SqlDataSource([url: 'jdbc:h2:mem:', user: '', password: ''])
+        then:
+        ds.user == SqlDataSource.DEFAULT_USER
+        ds.password == null
+    }
+
+    def 'should detect unresolved secrets.* pattern' () {
+        when:
+        new SqlDataSource([user: 'secrets.ATHENA_USER'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Unresolved secret detected for user")
+        e.message.contains("secrets.ATHENA_USER")
+        e.message.contains("workspace secrets are not properly configured")
+    }
+
+    def 'should detect unresolved [secret] pattern' () {
+        when:
+        new SqlDataSource([password: '[secret]'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Unresolved secret detected for password")
+        e.message.contains("[secret]")
+        e.message.contains("workspace secrets are not properly configured")
+    }
+
+    def 'should allow valid secret-like strings that are not unresolved' () {
+        when:
+        def ds = new SqlDataSource([user: 'mysecret', password: 'secretpassword'])
+        then:
+        ds.user == 'mysecret'
+        ds.password == 'secretpassword'
+    }
+
+    def 'should handle secrets in fallback constructor' () {
+        given:
+        def fallback = new SqlDataSource([user: 'fallback_user', password: 'fallback_pass'])
+        
+        when:
+        new SqlDataSource([user: 'secrets.ATHENA_USER'], fallback)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("Unresolved secret detected for user")
+    }
+
+    def 'should provide comprehensive error message for secrets' () {
+        when:
+        new SqlDataSource([user: 'secrets.MISSING_SECRET'])
+        then:
+        def e = thrown(IllegalArgumentException)
+        with(e.message) {
+            contains("Unresolved secret detected")
+            contains("secrets.MISSING_SECRET")
+            contains("workspace secrets are not properly configured")
+            contains("secret is defined in your workspace")
+            contains("secret name matches exactly")
+            contains("proper permissions")
+            contains("Nextflow version supports secrets")
+            contains("https://www.nextflow.io/docs/latest/secrets.html")
+        }
+    }
 }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -145,11 +145,17 @@ class SqlDataSourceTest extends Specification {
         pattern << ['secrets.ATHENA_USER', '[secret]']
     }
 
-    def 'should allow valid credentials' () {
+    def 'should handle various credential inputs' () {
         when:
-        def ds = new SqlDataSource([user: 'validuser', password: 'validpass'])
+        def ds = new SqlDataSource([user: userInput, password: passInput])
         then:
-        ds.user == 'validuser'
-        ds.password == 'validpass'
+        ds.user == expectedUser
+        ds.password == expectedPass
+
+        where:
+        userInput    | passInput    | expectedUser              | expectedPass
+        'validuser'  | 'validpass'  | 'validuser'              | 'validpass'
+        null         | null         | SqlDataSource.DEFAULT_USER| null
+        ''           | ''           | SqlDataSource.DEFAULT_USER| null
     }
 }


### PR DESCRIPTION
Fixes silent fallback to default credentials when workspace secrets aren't resolved.
This pull request adds robust support for using secrets as database credentials in nf-sqldb plugin configurations, with improved error handling and documentation. 

Added some documentation and some tests for it as well!