### PR TITLE
Allow pluggable QueryOp provider for fromQuery

### DIFF
--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -69,14 +69,49 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      * Factory used to create the {@link QueryOp} instance backing the {@code fromQuery}
      * channel factory. Defaults to {@link QueryHandler}. A downstream plugin can supply
      * its own implementation via {@link #registerQueryOpProvider(groovy.lang.Closure)}.
+     * <p>
+     * Volatile because registration typically happens on the plugin-start thread while
+     * {@link #createQueryOp()} runs on DSL/operator threads; without this, readers are not
+     * guaranteed to ever observe a published provider.
+     * <p>
+     * <b>Limitations for downstream plugins:</b>
+     * <ul>
+     *     <li>The registering plugin must declare an actual dependency on {@code nf-sqldb}
+     *         so it shares this exact {@code ChannelSqlExtension} class. A shaded/bundled
+     *         copy of this class loaded by the plugin will register against its own copy
+     *         of this static field, and {@code fromQuery} will silently keep using the
+     *         default {@link QueryHandler}.</li>
+     *     <li>This static field pins a reference to the closure, and transitively to the
+     *         classloader of the plugin that registered it. A plugin that is stopped or
+     *         unloaded must call {@link #unregisterQueryOpProvider()} (or register
+     *         {@code null}); otherwise its classloader leaks and {@code fromQuery} keeps
+     *         dispatching into a provider backed by a dead plugin.</li>
+     * </ul>
      */
-    private static Closure<QueryOp> queryOpProvider
+    private static volatile Closure<QueryOp> queryOpProvider
 
     /**
-     * Register a custom {@link QueryOp} provider. Pass {@code null} to restore the default.
+     * Register a custom {@link QueryOp} provider. Pass {@code null} to restore the default,
+     * or call {@link #unregisterQueryOpProvider()} instead for a clearer call site.
+     * <p>
+     * If a different, non-null provider is already registered, it is overwritten and a
+     * warning is logged, since this usually indicates two plugins competing for the same
+     * hook.
      */
     static void registerQueryOpProvider(Closure<QueryOp> provider) {
+        final current = queryOpProvider
+        if( current!=null && provider!=null && current!=provider )
+            log.warn("Overwriting an existing QueryOp provider - this usually means two plugins are registering competing QueryOp providers")
         queryOpProvider = provider
+    }
+
+    /**
+     * Remove any previously registered {@link QueryOp} provider, restoring the default
+     * {@link QueryHandler} behavior. A plugin that registered a provider should call this
+     * when it is stopped or unloaded to avoid pinning its classloader.
+     */
+    static void unregisterQueryOpProvider() {
+        queryOpProvider = null
     }
 
     protected QueryOp createQueryOp() {

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -79,7 +79,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
     /**
      * Register a custom {@link QueryOp} provider used by {@code fromQuery} in place of the
      * default {@link QueryHandler}. Pass {@code null} to restore the default, or call
-     * {@link #unregisterQueryOpProvider()} instead for a clearer call site.
+     * {@link #unregisterQueryOpProvider(groovy.lang.Closure)} instead for a clearer call site.
      * <p>
      * If a different, non-null provider is already registered, it is overwritten and a
      * warning is logged, since this usually indicates two plugins competing for the same
@@ -94,7 +94,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      *         default {@link QueryHandler}.</li>
      *     <li>This static field pins a reference to the closure, and transitively to the
      *         classloader of the plugin that registered it. A plugin that is stopped or
-     *         unloaded must call {@link #unregisterQueryOpProvider()} (or register
+     *         unloaded must call {@link #unregisterQueryOpProvider(groovy.lang.Closure)} (or
      *         {@code null}); otherwise its classloader leaks and {@code fromQuery} keeps
      *         dispatching into a provider backed by a dead plugin.</li>
      *     <li>The {@code provider} closure is invoked with no arguments and has no access
@@ -103,7 +103,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      *         registration time.</li>
      * </ul>
      */
-    static void registerQueryOpProvider(Closure<QueryOp> provider) {
+    static synchronized void registerQueryOpProvider(Closure<QueryOp> provider) {
         final current = queryOpProvider
         if( current!=null && provider!=null && current!=provider )
             log.warn("Overwriting an existing QueryOp provider - this usually means two plugins are registering competing QueryOp providers")
@@ -111,11 +111,24 @@ class ChannelSqlExtension extends PluginExtensionPoint {
     }
 
     /**
-     * Remove any previously registered {@link QueryOp} provider, restoring the default
-     * {@link QueryHandler} behavior. A plugin that registered a provider should call this
-     * when it is stopped or unloaded to avoid pinning its classloader.
+     * Remove a previously registered {@link QueryOp} provider, restoring the default
+     * {@link QueryHandler} behavior, but only if {@code provider} is still the currently
+     * registered one (identity match). A plugin that registered a provider should call
+     * this with the same closure when it is stopped or unloaded, to avoid pinning its
+     * classloader.
+     * <p>
+     * If a different provider is currently registered (e.g. another plugin has since
+     * overwritten it), the current registration is left untouched and a warning is
+     * logged, since clearing it would silently disable that other plugin's hook.
      */
-    static void unregisterQueryOpProvider() {
+    static synchronized void unregisterQueryOpProvider(Closure<QueryOp> provider) {
+        final current = queryOpProvider
+        if( current==null )
+            return
+        if( current!=provider ) {
+            log.warn("Ignoring unregisterQueryOpProvider call - the currently registered QueryOp provider does not match the one being unregistered")
+            return
+        }
         queryOpProvider = null
     }
 

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -105,7 +105,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      */
     static synchronized void registerQueryOpProvider(Closure<QueryOp> provider) {
         final current = queryOpProvider
-        if( current!=null && provider!=null && current!=provider )
+        if( current!=null && provider!=null && !current.is(provider) )
             log.warn("Overwriting an existing QueryOp provider - this usually means two plugins are registering competing QueryOp providers")
         queryOpProvider = provider
     }
@@ -125,7 +125,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
         final current = queryOpProvider
         if( current==null )
             return
-        if( current!=provider ) {
+        if( !current.is(provider) ) {
             log.warn("Ignoring unregisterQueryOpProvider call - the currently registered QueryOp provider does not match the one being unregistered")
             return
         }

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -73,8 +73,19 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      * Volatile because registration typically happens on the plugin-start thread while
      * {@link #createQueryOp()} runs on DSL/operator threads; without this, readers are not
      * guaranteed to ever observe a published provider.
+     */
+    private static volatile Closure<QueryOp> queryOpProvider
+
+    /**
+     * Register a custom {@link QueryOp} provider used by {@code fromQuery} in place of the
+     * default {@link QueryHandler}. Pass {@code null} to restore the default, or call
+     * {@link #unregisterQueryOpProvider()} instead for a clearer call site.
      * <p>
-     * <b>Limitations for downstream plugins:</b>
+     * If a different, non-null provider is already registered, it is overwritten and a
+     * warning is logged, since this usually indicates two plugins competing for the same
+     * hook.
+     * <p>
+     * <b>Prerequisites and limitations for callers:</b>
      * <ul>
      *     <li>The registering plugin must declare an actual dependency on {@code nf-sqldb}
      *         so it shares this exact {@code ChannelSqlExtension} class. A shaded/bundled
@@ -86,17 +97,11 @@ class ChannelSqlExtension extends PluginExtensionPoint {
      *         unloaded must call {@link #unregisterQueryOpProvider()} (or register
      *         {@code null}); otherwise its classloader leaks and {@code fromQuery} keeps
      *         dispatching into a provider backed by a dead plugin.</li>
+     *     <li>The {@code provider} closure is invoked with no arguments and has no access
+     *         to the current {@code session}, {@code opts}, or resolved {@code SqlDataSource}
+     *         — a provider that needs any of that state must capture it itself at
+     *         registration time.</li>
      * </ul>
-     */
-    private static volatile Closure<QueryOp> queryOpProvider
-
-    /**
-     * Register a custom {@link QueryOp} provider. Pass {@code null} to restore the default,
-     * or call {@link #unregisterQueryOpProvider()} instead for a clearer call site.
-     * <p>
-     * If a different, non-null provider is already registered, it is overwritten and a
-     * warning is logged, since this usually indicates two plugins competing for the same
-     * hook.
      */
     static void registerQueryOpProvider(Closure<QueryOp> provider) {
         final current = queryOpProvider

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -65,6 +65,30 @@ class ChannelSqlExtension extends PluginExtensionPoint {
             setup: CharSequence
     ]
 
+    /**
+     * Factory used to create the {@link QueryOp} instance backing the {@code fromQuery}
+     * channel factory. Defaults to {@link QueryHandler}. A downstream plugin can supply
+     * its own implementation via {@link #registerQueryOpProvider(groovy.lang.Closure)}.
+     */
+    private static Closure<QueryOp> queryOpProvider
+
+    /**
+     * Register a custom {@link QueryOp} provider. Pass {@code null} to restore the default.
+     */
+    static void registerQueryOpProvider(Closure<QueryOp> provider) {
+        queryOpProvider = provider
+    }
+
+    protected QueryOp createQueryOp() {
+        final provider = queryOpProvider
+        if( !provider )
+            return new QueryHandler()
+        final result = provider.call()
+        if( result==null )
+            throw new IllegalStateException("QueryOp provider returned a null instance")
+        return result
+    }
+
     private Session session
     private SqlConfig config
 
@@ -87,7 +111,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
     protected DataflowWriteChannel queryToChannel(String query, Map opts) {
         final channel = CH.create()
         final dataSource = dataSourceFromOpts(opts)
-        final handler = new QueryHandler()
+        final handler = createQueryOp()
                 .withDataSource(dataSource)
                 .withStatement(query)
                 .withTarget(channel)

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -156,6 +156,10 @@ class ChannelSqlExtensionTest extends Specification {
         given:
         def opA = { -> Mock(QueryOp) }
         def opB = { -> Mock(QueryOp) }
+        def logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ChannelSqlExtension)
+        def appender = new ch.qos.logback.core.read.ListAppender()
+        appender.start()
+        logger.addAppender(appender)
 
         when:
         ChannelSqlExtension.registerQueryOpProvider(opA)
@@ -163,6 +167,10 @@ class ChannelSqlExtensionTest extends Specification {
 
         then:
         noExceptionThrown()
+        appender.list.any { it.formattedMessage.contains('Overwriting an existing QueryOp provider') }
+
+        cleanup:
+        logger.detachAppender(appender)
     }
 
     def 'should unregister a provider that matches by identity' () {

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -126,7 +126,7 @@ class ChannelSqlExtensionTest extends Specification {
     }
 
     def cleanup() {
-        ChannelSqlExtension.unregisterQueryOpProvider()
+        ChannelSqlExtension.registerQueryOpProvider(null)
     }
 
     def 'should use default QueryHandler when no provider is registered' () {
@@ -163,6 +163,47 @@ class ChannelSqlExtensionTest extends Specification {
 
         then:
         noExceptionThrown()
+    }
+
+    def 'should unregister a provider that matches by identity' () {
+        given:
+        def customOp = Mock(QueryOp)
+        def provider = { -> customOp }
+        ChannelSqlExtension.registerQueryOpProvider(provider)
+
+        when:
+        ChannelSqlExtension.unregisterQueryOpProvider(provider)
+
+        then:
+        new ChannelSqlExtension().createQueryOp() instanceof QueryHandler
+    }
+
+    def 'should not unregister a provider that does not match by identity' () {
+        given:
+        def customOp = Mock(QueryOp) {
+            withDataSource(_) >> it
+            withStatement(_) >> it
+            withTarget(_) >> it
+            withOpts(_) >> it
+        }
+        def ownerProvider = { -> customOp }
+        def otherProvider = { -> Mock(QueryOp) }
+        ChannelSqlExtension.registerQueryOpProvider(ownerProvider)
+        and:
+        def logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ChannelSqlExtension)
+        def appender = new ch.qos.logback.core.read.ListAppender()
+        appender.start()
+        logger.addAppender(appender)
+
+        when:
+        ChannelSqlExtension.unregisterQueryOpProvider(otherProvider)
+
+        then:
+        new ChannelSqlExtension().createQueryOp().is(customOp)
+        appender.list.any { it.formattedMessage.contains('Ignoring unregisterQueryOpProvider call') }
+
+        cleanup:
+        logger.detachAppender(appender)
     }
 
     def 'should use custom QueryOp when a provider is registered' () {

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -125,4 +125,38 @@ class ChannelSqlExtensionTest extends Specification {
         e.message.contains("Available databases:")
     }
 
+    def cleanup() {
+        ChannelSqlExtension.registerQueryOpProvider(null)
+    }
+
+    def 'should use default QueryHandler when no provider is registered' () {
+        given:
+        def sqlExtension = new ChannelSqlExtension()
+
+        expect:
+        sqlExtension.createQueryOp() instanceof QueryHandler
+    }
+
+    def 'should use custom QueryOp when a provider is registered' () {
+        given:
+        def customOp = Mock(QueryOp) {
+            withDataSource(_) >> it
+            withStatement(_) >> it
+            withTarget(_) >> it
+            withOpts(_) >> it
+        }
+        ChannelSqlExtension.registerQueryOpProvider({ -> customOp })
+        and:
+        def session = Mock(Session) {
+            getConfig() >> [sql: [db: [default: [url: 'jdbc:h2:mem:custom_op_test']]]]
+        }
+        def sqlExtension = new ChannelSqlExtension(); sqlExtension.init(session)
+
+        when:
+        sqlExtension.fromQuery('select * from FOO')
+
+        then:
+        1 * customOp.perform(true)
+    }
+
 }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/ChannelSqlExtensionTest.groovy
@@ -126,15 +126,43 @@ class ChannelSqlExtensionTest extends Specification {
     }
 
     def cleanup() {
-        ChannelSqlExtension.registerQueryOpProvider(null)
+        ChannelSqlExtension.unregisterQueryOpProvider()
     }
 
     def 'should use default QueryHandler when no provider is registered' () {
         given:
-        def sqlExtension = new ChannelSqlExtension()
+        def JDBC_URL = 'jdbc:h2:mem:test_' + Random.newInstance().nextInt(1_000_000)
+        def sql = Sql.newInstance(JDBC_URL, 'sa', null)
+        and:
+        sql.execute('create table FOO(id int primary key, alpha varchar(255));')
+        sql.execute("insert into FOO (id, alpha) values (1, 'hola') ")
+        and:
+        def session = Mock(Session) {
+            getConfig() >> [sql: [db: [test: [url: JDBC_URL]]]]
+        }
+        def sqlExtension = new ChannelSqlExtension(); sqlExtension.init(session)
 
         expect:
         sqlExtension.createQueryOp() instanceof QueryHandler
+
+        when:
+        def result = sqlExtension.fromQuery('select * from FOO', db: 'test')
+        then:
+        result.val == [1, 'hola']
+        result.val == Channel.STOP
+    }
+
+    def 'should warn when overwriting a competing provider' () {
+        given:
+        def opA = { -> Mock(QueryOp) }
+        def opB = { -> Mock(QueryOp) }
+
+        when:
+        ChannelSqlExtension.registerQueryOpProvider(opA)
+        ChannelSqlExtension.registerQueryOpProvider(opB)
+
+        then:
+        noExceptionThrown()
     }
 
     def 'should use custom QueryOp when a provider is registered' () {


### PR DESCRIPTION
`ChannelSqlExtension.fromQuery` always builds a `QueryHandler` directly, even though the query execution behind it is already abstracted behind a `QueryOp` interface. That makes it impossible for a downstream Nextflow plugin to swap in its own `QueryOp` implementation without forking this extension.

This adds a small static hook, `ChannelSqlExtension.registerQueryOpProvider(Closure<QueryOp> provider)` and `unregisterQueryOpProvider(Closure<QueryOp> provider)`, that lets a plugin register a factory closure returning a custom `QueryOp`. With no provider registered, `fromQuery` behaves exactly as before, constructing a `QueryHandler`. Existing `fromQuery` options and wiring (`withStatement`, `withTarget`, `withDataSource`, `withOpts`) are untouched.

I went with a static factory closure rather than adding a new extension-point interface, since there's currently only one `QueryOp` implementation and a closure/setter felt like the minimal change.

- Registration state is read unsynchronized (`volatile`) from `createQueryOp()` for the hot path, but `registerQueryOpProvider`/`unregisterQueryOpProvider` themselves are `synchronized`, so concurrent register/unregister calls can't race each other.
- Registering over an existing non-null provider logs a warning, since that usually means two plugins are competing for the same hook.
- `unregisterQueryOpProvider` is ownership-aware: it only clears the registration if the closure passed in is identical to the one currently registered. If plugin A registered, plugin B overwrote it, and A then calls unregister with its own closure, A's call is a no-op (with a warning) rather than silently disabling B's provider.

Known limitations of this shape, worth maintainer input on:

- **Class identity matters.** A plugin must depend on `nf-sqldb` rather than bundle/shade its own copy of `ChannelSqlExtension`; otherwise registration silently targets a different class and `fromQuery` keeps using the default.
- **Classloader lifetime.** The static field holds a reference to the registering plugin's closure (and transitively its classloader). A plugin that stops or unloads without calling `unregisterQueryOpProvider(provider)` leaks its classloader and leaves `fromQuery` dispatching into a provider backed by a now-dead plugin.
- **No context passed to the closure.** The provider closure receives no arguments — no `session`, `opts`, or `dataSource` — so a provider that needs any of that has to capture it itself at registration time, which is fragile if that state changes across calls.

Given these, I'd welcome feedback on whether this static-closure shape is acceptable as-is, or whether it should instead be a typed factory interface, or go through the existing `PluginExtensionPoint` mechanism for a lifecycle-aware registration. Happy to iterate before this is finalized.
