### PR TITLE
Support JDBC driver properties per data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ The following options are available:
 `sql.db.'<DB-NAME>'.password`
 : The database connection password.
 
+`sql.db.'<DB-NAME>'.properties`
+: A map of additional JDBC driver connection properties, passed through verbatim to the
+  driver (optional). Use this for driver-specific settings that have no dedicated option,
+  for example SSL or session parameters. If `user` or `password` is also given at the top
+  level, it takes precedence over an entry of the same name in `properties`. Property
+  values are redacted from log and debug output.
+
+```
+sql {
+    db {
+        foo {
+            url = 'jdbc:mysql://localhost:3306/demo'
+            user = 'my-name'
+            password = 'my-password'
+            properties = [
+                sslMode: 'REQUIRED',
+                connectTimeout: '5000'
+            ]
+        }
+    }
+}
+```
+
 For information on using secrets with database credentials, see [docs/secrets.md](docs/secrets.md).
 
 ## Dataflow Operators

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -38,7 +38,6 @@ import nextflow.sql.config.SqlDataSource
 import nextflow.util.CheckHelper
 import java.sql.Connection
 import java.sql.Statement
-import groovy.sql.Sql
 /**
  * Provide a channel factory extension that allows the execution of Sql queries
  *
@@ -172,7 +171,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
             return [success: false, error: msg]
         }
         
-        try (Connection conn = groovy.sql.Sql.newInstance(dataSource.toMap()).getConnection()) {
+        try (Connection conn = dataSource.getConnection()) {
             try (Statement stm = conn.createStatement()) {
                 String normalizedStatement = normalizeStatement(statement)
                 

--- a/plugins/nf-sqldb/src/main/nextflow/sql/InsertHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/InsertHandler.groovy
@@ -21,7 +21,6 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.SQLFeatureNotSupportedException
 
-import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.transform.stc.ClosureParams
@@ -87,7 +86,7 @@ class InsertHandler implements Closeable {
 
     private Connection getConnection() {
         if( connection == null ) {
-            connection = Sql.newInstance(ds.toMap()).getConnection()
+            connection = ds.getConnection()
             checkCreate(connection)
             safeSetAutoCommit(connection, false)
         }

--- a/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
@@ -23,7 +23,6 @@ import java.sql.ResultSet
 import java.sql.Statement
 import java.util.concurrent.CompletableFuture
 
-import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import groovyx.gpars.dataflow.DataflowWriteChannel
@@ -120,7 +119,7 @@ class QueryHandler implements QueryOp<QueryHandler> {
 
     protected Connection connect(SqlDataSource ds) {
         log.debug "Creating SQL connection: ${ds}"
-        Sql.newInstance(ds.toMap()).getConnection()
+        ds.getConnection()
     }
 
     protected String normalize(String q) {

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -65,14 +65,21 @@ class SqlDataSource {
      *
      * @param value The `properties` config value
      * @return An immutable map of driver properties, or an empty map when not specified
+     * @throws IllegalArgumentException if the value is not a map
      */
     protected Map<String,String> resolveProperties(Object value) {
-        if( !(value instanceof Map) )
+        if( value == null )
             return Collections.<String,String>emptyMap()
+        if( !(value instanceof Map) )
+            throw new IllegalArgumentException(
+                    "Invalid 'properties' setting for the SQL data source -- " +
+                    "it must be a map of JDBC driver properties, offending value: '$value' [${value.getClass().getName()}]")
         final result = new LinkedHashMap<String,String>()
         for( Map.Entry entry : (value as Map) ) {
-            if( entry.value != null )
-                result.put(entry.key.toString(), entry.value.toString())
+            final key = entry.key.toString()
+            final val = resolveCredential(entry.value, "properties.$key".toString())
+            if( val != null )
+                result.put(key, val)
         }
         return Collections.unmodifiableMap(result)
     }
@@ -158,4 +165,3 @@ class SqlDataSource {
         return "SqlDataSource[url=$url; driver=$driver; user=$user; password=${Bolts.redact(password)}; properties=$redactedProps]"
     }
 }
-

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -17,6 +17,9 @@
 
 package nextflow.sql.config
 
+import java.sql.Connection
+
+import groovy.sql.Sql
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import nextflow.extension.Bolts
@@ -39,12 +42,14 @@ class SqlDataSource {
     String url
     String user
     String password
+    Map<String,String> properties
 
     SqlDataSource(Map opts) {
         this.url = opts.url ?: DEFAULT_URL
         this.driver = opts.driver ?: urlToDriver(url) ?: DEFAULT_DRIVER
         this.user = resolveCredential(opts.user, 'user') ?: DEFAULT_USER
         this.password = resolveCredential(opts.password, 'password')
+        this.properties = resolveProperties(opts.properties)
     }
 
     SqlDataSource(Map opts, SqlDataSource fallback) {
@@ -52,6 +57,24 @@ class SqlDataSource {
         this.driver = opts.driver ?: urlToDriver(url) ?: fallback.driver ?: DEFAULT_DRIVER
         this.user = resolveCredential(opts.user, 'user') ?: fallback.user ?: DEFAULT_USER
         this.password = resolveCredential(opts.password, 'password') ?: fallback.password
+        this.properties = opts.properties!=null ? resolveProperties(opts.properties) : fallback.properties
+    }
+
+    /**
+     * Normalise the JDBC driver properties declared in the config into a map of strings
+     *
+     * @param value The `properties` config value
+     * @return An immutable map of driver properties, or an empty map when not specified
+     */
+    protected Map<String,String> resolveProperties(Object value) {
+        if( !(value instanceof Map) )
+            return Collections.<String,String>emptyMap()
+        final result = new LinkedHashMap<String,String>()
+        for( Map.Entry entry : (value as Map) ) {
+            if( entry.value != null )
+                result.put(entry.key.toString(), entry.value.toString())
+        }
+        return Collections.unmodifiableMap(result)
     }
 
     protected String urlToDriver(String url) {
@@ -103,8 +126,36 @@ class SqlDataSource {
         return result
     }
 
+    /**
+     * Opens a JDBC connection for this data source.
+     *
+     * When driver {@code properties} are configured, they are merged with the top-level
+     * {@code user}/{@code password} credentials into a single {@link Properties} instance
+     * -- with the top-level credentials taking precedence over same-named entries in
+     * {@code properties} -- and the connection is opened via the url + Properties + driver
+     * overload, because {@code groovy.sql.Sql.newInstance(Map)} does not allow both
+     * {@code properties} and {@code user}/{@code password} to be set at the same time.
+     * When no properties are configured, the existing map-based connection path is preserved.
+     *
+     * @return An open {@link Connection}
+     */
+    Connection getConnection() {
+        if( !properties )
+            return Sql.newInstance(toMap()).getConnection()
+
+        final props = new Properties()
+        props.putAll(properties)
+        if( user!=null )
+            props.setProperty('user', user)
+        if( password!=null )
+            props.setProperty('password', password)
+        return Sql.newInstance(url, props, driver).getConnection()
+    }
+
     @Override
     String toString() {
-        return "SqlDataSource[url=$url; driver=$driver; user=$user; password=${Bolts.redact(password)}]"
+        final redactedProps = properties?.collectEntries { k, v -> [k, Bolts.redact(v)] }
+        return "SqlDataSource[url=$url; driver=$driver; user=$user; password=${Bolts.redact(password)}; properties=$redactedProps]"
     }
 }
+

--- a/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
@@ -51,6 +51,47 @@ class QueryHandlerTest extends Specification {
         conn.close()
     }
 
+    def 'should pass configured properties to the jdbc driver' () {
+        given:
+        def ext = new QueryHandler()
+        and: 'a datasource with a driver property that changes observable H2 behaviour'
+        def JDBC_URL = 'jdbc:h2:mem:test_props_' + Random.newInstance().nextInt(1_000_000)
+        def ds = new SqlDataSource([url: JDBC_URL, properties: [IGNORECASE: 'TRUE']])
+
+        when:
+        def conn = ext.connect(ds)
+        and:
+        def stm = conn.createStatement()
+        stm.execute("create table FOO(id int primary key, alpha varchar(255))")
+        stm.execute("insert into FOO (id, alpha) values (1, 'HELLO')")
+        and: 'the query below only matches when the IGNORECASE property reached the driver'
+        def rs = stm.executeQuery("select * from FOO where alpha = 'hello'")
+
+        then:
+        rs.next()
+        rs.getString('alpha') == 'HELLO'
+
+        cleanup:
+        conn.close()
+    }
+
+    def 'should let top-level credentials win over same-named properties' () {
+        given:
+        def ext = new QueryHandler()
+        and:
+        def JDBC_URL = 'jdbc:h2:mem:test_props_cred_' + Random.newInstance().nextInt(1_000_000)
+        def ds = new SqlDataSource([url: JDBC_URL, user: 'sa', properties: [user: 'bogus']])
+
+        when:
+        def conn = ext.connect(ds)
+
+        then:
+        conn != null
+
+        cleanup:
+        conn?.close()
+    }
+
     def 'should perform query' () {
         given:
         def folder = Files.createTempDirectory('test')

--- a/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
@@ -23,7 +23,6 @@ import groovy.sql.Sql
 import groovyx.gpars.dataflow.DataflowQueue
 import nextflow.Channel
 import nextflow.sql.config.SqlDataSource
-import spock.lang.PendingFeature
 import spock.lang.Specification
 /**
  *
@@ -116,7 +115,6 @@ class QueryHandlerTest extends Specification {
         folder?.deleteDir()
     }
 
-    @PendingFeature(reason = 'a non-map properties value is silently ignored instead of rejected')
     def 'should reject a non-map properties setting' () {
         when:
         new SqlDataSource([url: 'jdbc:h2:mem:', properties: 'ssl=true'])
@@ -126,7 +124,6 @@ class QueryHandlerTest extends Specification {
         e.message.contains("must be a map of JDBC driver properties")
     }
 
-    @PendingFeature(reason = 'unresolved secrets in property values are not checked yet')
     def 'should reject an unresolved secret in a property value' () {
         when:
         new SqlDataSource([url: 'jdbc:h2:mem:', properties: [password: 'secrets.DB_PASSWORD']])

--- a/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
@@ -23,6 +23,7 @@ import groovy.sql.Sql
 import groovyx.gpars.dataflow.DataflowQueue
 import nextflow.Channel
 import nextflow.sql.config.SqlDataSource
+import spock.lang.PendingFeature
 import spock.lang.Specification
 /**
  *
@@ -75,7 +76,7 @@ class QueryHandlerTest extends Specification {
         conn.close()
     }
 
-    def 'should let top-level credentials win over same-named properties' () {
+    def 'should let top-level user win over same-named property' () {
         given:
         def ext = new QueryHandler()
         and:
@@ -85,11 +86,55 @@ class QueryHandlerTest extends Specification {
         when:
         def conn = ext.connect(ds)
 
-        then:
-        conn != null
+        then: 'the effective connection user is the top-level one, not the property'
+        conn.metaData.userName.equalsIgnoreCase('sa')
 
         cleanup:
         conn?.close()
+    }
+
+    def 'should let top-level password win over same-named property' () {
+        given:
+        def ext = new QueryHandler()
+        and: 'a file-backed db pre-created with known credentials so a wrong password is rejected'
+        def folder = Files.createTempDirectory('test-pwd')
+        def JDBC_URL = "jdbc:h2:${folder.resolve('testdb')}"
+        def sql = Sql.newInstance(JDBC_URL, 'sa', 'right-pass', 'org.h2.Driver')
+        sql.execute('create table FOO(id int primary key)' as String)
+        sql.close()
+
+        when: 'the top-level password is correct but the property one is wrong'
+        def ds = new SqlDataSource([url: JDBC_URL, user: 'sa', password: 'right-pass', properties: [password: 'wrong-pass']])
+        def conn = ext.connect(ds)
+
+        then: 'the connection succeeds, proving the top-level password was used'
+        conn != null
+        conn.metaData.userName.equalsIgnoreCase('sa')
+
+        cleanup:
+        conn?.close()
+        folder?.deleteDir()
+    }
+
+    @PendingFeature(reason = 'a non-map properties value is silently ignored instead of rejected')
+    def 'should reject a non-map properties setting' () {
+        when:
+        new SqlDataSource([url: 'jdbc:h2:mem:', properties: 'ssl=true'])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("must be a map of JDBC driver properties")
+    }
+
+    @PendingFeature(reason = 'unresolved secrets in property values are not checked yet')
+    def 'should reject an unresolved secret in a property value' () {
+        when:
+        new SqlDataSource([url: 'jdbc:h2:mem:', properties: [password: 'secrets.DB_PASSWORD']])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('Unresolved secret detected')
+        e.message.contains('properties.password')
     }
 
     def 'should perform query' () {

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -158,4 +158,42 @@ class SqlDataSourceTest extends Specification {
         null         | null         | SqlDataSource.DEFAULT_USER| null
         ''           | ''           | SqlDataSource.DEFAULT_USER| null
     }
+    def 'should default properties to empty map' () {
+        given:
+        def ds = new SqlDataSource([:])
+        expect:
+        ds.properties == [:]
+    }
+
+    def 'should parse driver properties from config' () {
+        given:
+        def ds = new SqlDataSource([url:'x', driver:'y', properties: [ssl: 'true', ACCESS_MODE_DATA: 'r']])
+        expect:
+        ds.properties == [ssl: 'true', ACCESS_MODE_DATA: 'r']
+    }
+
+    def 'should inherit properties from fallback when not set' () {
+        given:
+        def fallback = new SqlDataSource([driver:'y', properties: [ssl: 'true']])
+        def ds = new SqlDataSource([url:'x', driver:'y'], fallback)
+        expect:
+        ds.properties == [ssl: 'true']
+    }
+
+    def 'should override fallback properties when set' () {
+        given:
+        def fallback = new SqlDataSource([driver:'y', properties: [ssl: 'true']])
+        def ds = new SqlDataSource([url:'x', driver:'y', properties: [ssl: 'false']], fallback)
+        expect:
+        ds.properties == [ssl: 'false']
+    }
+
+    def 'should redact secrets in string representation' () {
+        given:
+        def ds = new SqlDataSource([url:'x', driver:'y', password: 'secret-pass', properties: [password: 'secret-prop', ssl: 'true']])
+        expect:
+        !ds.toString().contains('secret-pass')
+        !ds.toString().contains('secret-prop')
+        ds.toString().contains('ssl')
+    }
 }


### PR DESCRIPTION
Some drivers need extra connection properties (SSL settings, timeouts, driver-specific tuning flags, etc.) that aren't covered by url/driver/user/password. This adds an optional `sql.db.<name>.properties` map that gets passed through to the JDBC driver.

Groovy's `Sql.newInstance(Map)` rejects a call that sets both `properties` and `user`/`password`, so when properties are configured we build a single `Properties` payload (driver properties + credentials) and connect via the url + Properties + driver overload instead. Top-level `user`/`password` always win over same-named entries in `properties`. Connections with no properties configured are unaffected — they still go through the existing map-based path.

`toString()` redacts `password` and all `properties` values so they don't leak into logs.

### Validation

A non-map `properties` value (e.g. `properties = 'ssl=true'`) is rejected with an explicit error naming the offending value and its type. Returning an empty map there would have silently dropped the setting and fallen back to the legacy path — the same silent-drop behaviour this option exists to avoid.

Property values also go through the existing unresolved-secret check, so `properties.password = 'secrets.FOO'` fails the same way the top-level `password` does rather than being sent to the driver verbatim.

### Tests

Regression coverage is connection-level rather than assertions on `toMap()`:

- a property that changes observable H2 behaviour (`IGNORECASE`) proves pass-through actually reaches the driver;
- credential precedence asserts the effective user via `DatabaseMetaData.getUserName()`, and the password case uses a file-backed database pre-created with known credentials so a wrong password is genuinely rejected. Asserting only that a connection was returned would be vacuous — a fresh in-memory H2 database accepts whatever credentials the first connection supplies;
- both precedence tests were verified to fail when the merge order is deliberately inverted, and pass once restored.

`sql.db.'<DB-NAME>'.properties` is documented in the README alongside the existing options, including the precedence and redaction behaviour.