### PR TITLE
feat: add configurable connection login timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The following options are available:
 `sql.db.'<DB-NAME>'.password`
 : The database connection password.
 
+`sql.db.'<DB-NAME>'.timeout`
+: Max time to wait when establishing a connection, e.g. `'10s'` (optional, no timeout by default).
+
 For information on using secrets with database credentials, see [docs/secrets.md](docs/secrets.md).
 
 ## Dataflow Operators

--- a/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/ChannelSqlExtension.groovy
@@ -38,7 +38,6 @@ import nextflow.sql.config.SqlDataSource
 import nextflow.util.CheckHelper
 import java.sql.Connection
 import java.sql.Statement
-import groovy.sql.Sql
 /**
  * Provide a channel factory extension that allows the execution of Sql queries
  *
@@ -172,7 +171,7 @@ class ChannelSqlExtension extends PluginExtensionPoint {
             return [success: false, error: msg]
         }
         
-        try (Connection conn = groovy.sql.Sql.newInstance(dataSource.toMap()).getConnection()) {
+        try (Connection conn = dataSource.connect()) {
             try (Statement stm = conn.createStatement()) {
                 String normalizedStatement = normalizeStatement(statement)
                 

--- a/plugins/nf-sqldb/src/main/nextflow/sql/InsertHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/InsertHandler.groovy
@@ -21,7 +21,6 @@ import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.SQLFeatureNotSupportedException
 
-import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.transform.stc.ClosureParams
@@ -87,7 +86,7 @@ class InsertHandler implements Closeable {
 
     private Connection getConnection() {
         if( connection == null ) {
-            connection = Sql.newInstance(ds.toMap()).getConnection()
+            connection = ds.connect()
             checkCreate(connection)
             safeSetAutoCommit(connection, false)
         }

--- a/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
@@ -23,7 +23,6 @@ import java.sql.ResultSet
 import java.sql.Statement
 import java.util.concurrent.CompletableFuture
 
-import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import groovyx.gpars.dataflow.DataflowWriteChannel
@@ -120,7 +119,7 @@ class QueryHandler implements QueryOp<QueryHandler> {
 
     protected Connection connect(SqlDataSource ds) {
         log.debug "Creating SQL connection: ${ds}"
-        Sql.newInstance(ds.toMap()).getConnection()
+        ds.connect()
     }
 
     protected String normalize(String q) {

--- a/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/config/SqlDataSource.groovy
@@ -17,9 +17,23 @@
 
 package nextflow.sql.config
 
+import java.sql.Connection
+import java.sql.SQLException
+import java.sql.SQLTimeoutException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+import java.util.function.Supplier
+
+import groovy.sql.Sql
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import nextflow.extension.Bolts
+import nextflow.util.Duration
 
 /**
  * Model a dataSource configuration
@@ -39,12 +53,14 @@ class SqlDataSource {
     String url
     String user
     String password
+    Duration timeout
 
     SqlDataSource(Map opts) {
         this.url = opts.url ?: DEFAULT_URL
         this.driver = opts.driver ?: urlToDriver(url) ?: DEFAULT_DRIVER
         this.user = resolveCredential(opts.user, 'user') ?: DEFAULT_USER
         this.password = resolveCredential(opts.password, 'password')
+        this.timeout = resolveTimeout(opts.timeout)
     }
 
     SqlDataSource(Map opts, SqlDataSource fallback) {
@@ -52,7 +68,137 @@ class SqlDataSource {
         this.driver = opts.driver ?: urlToDriver(url) ?: fallback.driver ?: DEFAULT_DRIVER
         this.user = resolveCredential(opts.user, 'user') ?: fallback.user ?: DEFAULT_USER
         this.password = resolveCredential(opts.password, 'password') ?: fallback.password
+        this.timeout = resolveTimeout(opts.timeout) ?: fallback.timeout
     }
+
+    /**
+     * Parse the optional connection timeout, given either as a duration string,
+     * a {@link Duration} object or a number of seconds.
+     *
+     * @param value The timeout value from configuration, or null
+     * @return The corresponding {@link Duration} or null when not specified
+     */
+    protected Duration resolveTimeout(Object value) {
+        if( value == null )
+            return null
+        if( value instanceof Duration )
+            return value
+        if( value instanceof Number )
+            return Duration.of(Math.round(value.doubleValue() * 1_000) as long)
+        final str = value.toString().trim()
+        if( !str )
+            return null
+        return str.isLong()
+            ? Duration.of(str.toLong() * 1_000)
+            : new Duration(str)
+    }
+
+    /**
+     * @return The connection timeout in seconds, rounded up so any non-zero
+     *      sub-second value is never truncated away to zero. Zero itself means
+     *      "no timeout" and is returned unchanged. Only used for reporting/tests;
+     *      the actual bound is enforced with nanosecond precision.
+     */
+    Integer getTimeoutSecs() {
+        if( timeout == null )
+            return null
+        final millis = timeout.toMillis()
+        return millis <= 0 ? 0 : Math.max(1, (int) Math.ceil(millis / 1_000.0d))
+    }
+
+    // Caps the number of connect attempts that are still running on an abandoned
+    // daemon thread after their caller already gave up on them (see connectWithHardBound).
+    // Without a cap, a persistent outage would accumulate one leaked stuck thread (and
+    // potentially an unclosable connection) per timed-out attempt, without bound.
+    public static final int MAX_ABANDONED_CONNECT_ATTEMPTS = 16
+    private static final Semaphore ABANDONED_CONNECT_SLOTS = new Semaphore(MAX_ABANDONED_CONNECT_ATTEMPTS)
+
+    /**
+     * Open a new connection for this data source, bounding the time spent
+     * establishing it when a timeout is configured.
+     *
+     * @return A new JDBC {@link Connection}
+     */
+    Connection connect() {
+        final timeoutSecs = getTimeoutSecs()
+        if( timeoutSecs == null || timeoutSecs == 0 ) {
+            // unconfigured, or explicitly configured as zero: zero means "no timeout",
+            // not "immediate failure" -- run the connect with no bound, same as before
+            // this feature existed
+            return Sql.newInstance(toMap()).getConnection()
+        }
+        // Use nanosecond precision throughout so a sub-second configured timeout (e.g. '100ms')
+        // cannot be inflated by rounding to whole seconds.
+        final timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeout.toMillis())
+        return connectWithHardBound(timeoutNanos, timeout)
+    }
+
+    private static final AtomicLong CONNECT_THREAD_COUNTER = new AtomicLong()
+
+    /**
+     * Run the actual connection attempt on a background daemon thread and enforce
+     * the configured bound regardless of whether the underlying driver cooperates.
+     * {@code DriverManager#setLoginTimeout(int)} is intentionally not used: it is a
+     * JVM-global setting, so mutating it here could affect unrelated JDBC connects
+     * elsewhere in the same JVM, and it is advisory only -- plenty of drivers (e.g.
+     * trino-jdbc) never consult it anyway. This hard bound works independently of
+     * driver cooperation.
+     *
+     * @param remainingNanos time left to wait, in nanoseconds
+     * @param configuredTimeout the originally configured timeout, for error messages only
+     */
+    private Connection connectWithHardBound(long remainingNanos, Duration configuredTimeout) {
+        if( !ABANDONED_CONNECT_SLOTS.tryAcquire() )
+            throw new SQLTimeoutException(
+                "Too many connect attempts to datasource '$url' are already stuck past their configured " +
+                "timeout (limit: $MAX_ABANDONED_CONNECT_ATTEMPTS) -- refusing to start another; " +
+                "previous connection attempts to this datasource appear to still be stuck"
+            )
+        boolean abandoned = false
+        final executor = Executors.newSingleThreadExecutor { Runnable r ->
+            final t = new Thread(r, "sql-connect-${CONNECT_THREAD_COUNTER.incrementAndGet()}")
+            t.daemon = true
+            return t
+        }
+        try {
+            final future = CompletableFuture.supplyAsync({ Sql.newInstance(toMap()).getConnection() } as Supplier<Connection>, executor)
+            try {
+                return future.get(Math.max(0L, remainingNanos), TimeUnit.NANOSECONDS)
+            }
+            catch( TimeoutException e ) {
+                // the connect attempt may still complete (successfully) after we give up on
+                // it: attach whenComplete on the *original* future (not a cancelled one --
+                // CompletableFuture#cancel ignores mayInterruptIfRunning and would otherwise
+                // make whenComplete observe a CancellationException instead of the real,
+                // later result) so a late-arriving connection is closed instead of leaked,
+                // and the reserved slot is released either way.
+                abandoned = true
+                future.whenComplete { conn, err ->
+                    try {
+                        if( conn != null )
+                            try { conn.close() } catch( Exception ignored ) {}
+                    }
+                    finally {
+                        ABANDONED_CONNECT_SLOTS.release()
+                    }
+                }
+                throw new SQLTimeoutException("Timed out connecting to datasource '$url' after ${configuredTimeout}")
+            }
+            catch( ExecutionException e ) {
+                final cause = e.cause
+                throw cause instanceof SQLException ? cause : new SQLException("Failed to connect to datasource '$url'", cause)
+            }
+        }
+        finally {
+            // shutdownNow does not guarantee the connect attempt is interrupted if the
+            // driver is blocked in uninterruptible native I/O; the daemon thread may
+            // outlive this call, but it can never prevent JVM shutdown.
+            executor.shutdownNow()
+            if( !abandoned )
+                ABANDONED_CONNECT_SLOTS.release()
+        }
+    }
+
 
     protected String urlToDriver(String url) {
         DriverRegistry.DEFAULT.urlToDriver(url)
@@ -105,6 +251,6 @@ class SqlDataSource {
 
     @Override
     String toString() {
-        return "SqlDataSource[url=$url; driver=$driver; user=$user; password=${Bolts.redact(password)}]"
+        return "SqlDataSource[url=$url; driver=$driver; user=$user; password=${Bolts.redact(password)}; timeout=$timeout]"
     }
 }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/config/SqlDataSourceTest.groovy
@@ -17,7 +17,15 @@
 
 package nextflow.sql.config
 
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.DriverPropertyInfo
+import java.sql.SQLException
+import java.sql.SQLTimeoutException
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 
+import nextflow.util.Duration
 import spock.lang.Specification
 /**
  *
@@ -157,5 +165,288 @@ class SqlDataSourceTest extends Specification {
         'validuser'  | 'validpass'  | 'validuser'              | 'validpass'
         null         | null         | SqlDataSource.DEFAULT_USER| null
         ''           | ''           | SqlDataSource.DEFAULT_USER| null
+    }
+
+    def 'should connect and run a query against h2 with a timeout configured' () {
+        given:
+        def ds = new SqlDataSource([url: 'jdbc:h2:mem:timeout-smoke;DB_CLOSE_DELAY=-1', driver: 'org.h2.Driver', user: 'sa', timeout: '5s'])
+
+        when:
+        def conn = ds.connect()
+        def rs = conn.createStatement().executeQuery('SELECT 1')
+
+        then:
+        rs.next()
+        rs.getInt(1) == 1
+
+        cleanup:
+        conn?.close()
+    }
+
+    def 'should resolve timeout config' () {
+        expect:
+        new SqlDataSource([timeout: value]).timeout == expected
+        where:
+        value           | expected
+        null             | null
+        '5s'             | Duration.of('5s')
+        '500ms'          | Duration.of('500ms')
+        5                | Duration.of(5_000)
+        Duration.of('2m')| Duration.of('2m')
+    }
+
+    def 'should leave timeout unset by default' () {
+        expect:
+        new SqlDataSource([:]).timeout == null
+        new SqlDataSource([:]).timeoutSecs == null
+    }
+
+    def 'should convert timeout to seconds rounding up' () {
+        expect:
+        new SqlDataSource([timeout: value]).timeoutSecs == secs
+        where:
+        value    | secs
+        '5s'     | 5
+        '1500ms' | 2
+        '100ms'  | 1
+        '0s'     | 0
+    }
+
+    def 'should inherit timeout from fallback' () {
+        given:
+        def fallback = new SqlDataSource([timeout: '5s'])
+        expect:
+        new SqlDataSource([:], fallback).timeout == Duration.of('5s')
+        new SqlDataSource([timeout: '10s'], fallback).timeout == Duration.of('10s')
+    }
+
+    def 'should treat a configured zero timeout as no timeout, not immediate failure' () {
+        given:
+        DriverManager.registerDriver(new FakeDriver())
+        def ds = new SqlDataSource([url: FakeDriver.URL, driver: FakeDriver.name, user: 'sa', timeout: '0s'])
+
+        when:
+        def conn = ds.connect()
+
+        then:
+        ds.timeoutSecs == 0
+        conn != null
+
+        cleanup:
+        DriverManager.deregisterDriver(new FakeDriver())
+    }
+
+    def 'should bound a configured connect that blocks inside Driver#connect itself' () {
+        given:
+        // StuckFakeDriver never applies any login timeout, modeling a driver
+        // (e.g. trino-jdbc) that blocks forever in its own connect()
+        DriverManager.registerDriver(new StuckFakeDriver())
+        def ds = new SqlDataSource([url: StuckFakeDriver.URL, driver: StuckFakeDriver.name, user: 'sa', timeout: '1s'])
+        StuckFakeDriver.onConnect = { Thread.sleep(60_000) }
+
+        when:
+        def start = System.nanoTime()
+        ds.connect()
+
+        then:
+        def e = thrown(SQLTimeoutException)
+        e.message.contains('1s')
+        (System.nanoTime() - start) < TimeUnit.SECONDS.toNanos(5)
+
+        cleanup:
+        StuckFakeDriver.onConnect = null
+        DriverManager.deregisterDriver(new StuckFakeDriver())
+    }
+
+    def 'should not exceed a sub-second configured timeout by more than a small margin when the driver never returns' () {
+        given:
+        DriverManager.registerDriver(new StuckFakeDriver())
+        def ds = new SqlDataSource([url: StuckFakeDriver.URL, driver: StuckFakeDriver.name, user: 'sa', timeout: '100ms'])
+        StuckFakeDriver.onConnect = { Thread.sleep(60_000) }
+
+        when:
+        def start = System.nanoTime()
+        ds.connect()
+
+        then:
+        thrown(SQLTimeoutException)
+        // bounded with nanosecond precision, not rounded up to whole seconds
+        (System.nanoTime() - start) < TimeUnit.MILLISECONDS.toNanos(900)
+
+        cleanup:
+        StuckFakeDriver.onConnect = null
+        DriverManager.deregisterDriver(new StuckFakeDriver())
+    }
+
+    def 'should close a connection that completes after the configured deadline instead of leaking it' () {
+        given:
+        DriverManager.registerDriver(new StuckFakeDriver())
+        def ds = new SqlDataSource([url: StuckFakeDriver.URL, driver: StuckFakeDriver.name, user: 'sa', timeout: '200ms'])
+        def closed = new java.util.concurrent.CountDownLatch(1)
+        StuckFakeDriver.onConnect = {
+            final deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(600)
+            while( System.nanoTime() < deadline ) {
+                try { Thread.sleep(TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime()) + 1) }
+                catch( InterruptedException ignored ) { /* keep sleeping until the deadline regardless */ }
+            }
+        }
+        StuckFakeDriver.onClose = { closed.countDown() }
+
+        when:
+        ds.connect()
+
+        then:
+        thrown(SQLTimeoutException)
+        closed.await(5, TimeUnit.SECONDS)
+
+        cleanup:
+        StuckFakeDriver.onConnect = null
+        StuckFakeDriver.onClose = null
+        DriverManager.deregisterDriver(new StuckFakeDriver())
+    }
+
+    def 'should fail fast without spawning a new thread once abandoned connect attempts exhaust the cap, and release slots when they finally return' () {
+        given:
+        DriverManager.registerDriver(new StuckFakeDriver())
+        StuckFakeDriver.connectAttempts.set(0)
+        def ds = new SqlDataSource([url: StuckFakeDriver.URL, driver: StuckFakeDriver.name, user: 'sa', timeout: '100ms'])
+        def release = new java.util.concurrent.CountDownLatch(1)
+        StuckFakeDriver.onConnect = {
+            while( release.getCount() > 0 ) {
+                try { release.await(50, TimeUnit.MILLISECONDS) }
+                catch( InterruptedException ignored ) { /* ignore shutdownNow interruption, keep waiting */ }
+            }
+        }
+        def cap = SqlDataSource.MAX_ABANDONED_CONNECT_ATTEMPTS
+
+        when:
+        // exhaust the cap: each of these times out, abandoning its stuck background thread
+        cap.times {
+            try { ds.connect() } catch( SQLTimeoutException ignored ) {}
+        }
+
+        then:
+        StuckFakeDriver.connectAttempts.get() == cap
+
+        when:
+        // the cap is now exhausted: the very next attempt must fail immediately,
+        // without ever spawning another background thread (no new call into the driver)
+        def attemptsBefore = StuckFakeDriver.connectAttempts.get()
+        def start = System.nanoTime()
+        ds.connect()
+
+        then:
+        def e = thrown(SQLTimeoutException)
+        e.message.contains('stuck')
+        (System.nanoTime() - start) < TimeUnit.SECONDS.toNanos(1)
+        Thread.sleep(300)
+        StuckFakeDriver.connectAttempts.get() == attemptsBefore
+
+        when:
+        // release every abandoned attempt: their slots must be returned, letting a
+        // fresh connect (well within budget) succeed again
+        release.countDown()
+        StuckFakeDriver.onConnect = null
+        def deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10)
+        def conn = null
+        while( conn == null && System.nanoTime() < deadline ) {
+            try { conn = ds.connect() }
+            catch( SQLTimeoutException ignored ) { Thread.sleep(50) }
+        }
+
+        then:
+        conn != null
+
+        cleanup:
+        StuckFakeDriver.onConnect = null
+        StuckFakeDriver.connectAttempts.set(0)
+        DriverManager.deregisterDriver(new StuckFakeDriver())
+    }
+
+
+
+    /**
+     * Deterministic fake JDBC driver used for a plain connect, without any real I/O.
+     */
+    static class FakeDriver implements java.sql.Driver {
+        static final String URL = 'jdbc:faketimeout:test'
+
+        @Override
+        Connection connect(String url, java.util.Properties info) throws SQLException {
+            if( !acceptsURL(url) )
+                return null
+            return (Connection) java.lang.reflect.Proxy.newProxyInstance(
+                Connection.classLoader,
+                [Connection] as Class[],
+                { proxy, method, args -> method.name == 'isClosed' ? false : null } as java.lang.reflect.InvocationHandler
+            )
+        }
+
+        @Override
+        boolean acceptsURL(String url) throws SQLException { url == URL }
+
+        @Override
+        DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info) throws SQLException { new DriverPropertyInfo[0] }
+
+        @Override
+        int getMajorVersion() { 1 }
+
+        @Override
+        int getMinorVersion() { 0 }
+
+        @Override
+        boolean jdbcCompliant() { false }
+
+        @Override
+        Logger getParentLogger() throws java.sql.SQLFeatureNotSupportedException { null }
+    }
+
+    /**
+     * Fake driver whose {@code connect} runs an optional hook (e.g. an unbounded sleep)
+     * before returning -- simulates a driver that blocks indefinitely on the underlying
+     * transport, regardless of any configured timeout.
+     */
+    static class StuckFakeDriver implements java.sql.Driver {
+        static final String URL = 'jdbc:fakestucktimeout:test'
+        static volatile Closure onConnect = null
+        static volatile Closure onClose = null
+        static volatile java.util.concurrent.atomic.AtomicInteger connectAttempts = new java.util.concurrent.atomic.AtomicInteger()
+
+        @Override
+        Connection connect(String url, java.util.Properties info) throws SQLException {
+            if( !acceptsURL(url) )
+                return null
+            connectAttempts.incrementAndGet()
+            onConnect?.call()
+            return (Connection) java.lang.reflect.Proxy.newProxyInstance(
+                Connection.classLoader,
+                [Connection] as Class[],
+                { proxy, method, args ->
+                    if( method.name == 'isClosed' )
+                        return false
+                    if( method.name == 'close' )
+                        onClose?.call()
+                    return null
+                } as java.lang.reflect.InvocationHandler
+            )
+        }
+
+        @Override
+        boolean acceptsURL(String url) throws SQLException { url == URL }
+
+        @Override
+        DriverPropertyInfo[] getPropertyInfo(String url, java.util.Properties info) throws SQLException { new DriverPropertyInfo[0] }
+
+        @Override
+        int getMajorVersion() { 1 }
+
+        @Override
+        int getMinorVersion() { 0 }
+
+        @Override
+        boolean jdbcCompliant() { false }
+
+        @Override
+        Logger getParentLogger() throws java.sql.SQLFeatureNotSupportedException { null }
     }
 }


### PR DESCRIPTION
An unbounded connect can hang indefinitely if a database is unreachable, since no timeout bounds connection establishment. Statement/query timeouts don't help here: a blocked connect happens before a `Statement` exists.

This adds an optional `sql.db.'<DB-NAME>'.timeout` config setting. It accepts a duration string (`'5s'`), a number of seconds, or a `Duration`. Default behavior is unchanged: when `timeout` is not set, nothing here is touched. An explicit `timeout` of zero means "no timeout" (same as unset), not "fail immediately".

The configured bound is enforced by running the connect attempt on a background daemon thread and giving up with `Future#get(timeout, ...)` if it hasn't returned in time, failing with a clear error naming the datasource and the configured value. This does not rely on `DriverManager.setLoginTimeout()` at all: that setting is JVM-global (it can affect unrelated JDBC connects elsewhere in the same JVM, since Nextflow runs plugins in one JVM) and advisory only -- plenty of drivers (e.g. trino-jdbc) never consult it and rely on their own connection properties instead. The hard bound here works independently of driver cooperation.

The background thread is daemon so an abandoned, still-blocked attempt can never keep the JVM from exiting; interruption on give-up is attempted but not guaranteed if the driver is blocked in native I/O. If the attempt does eventually complete after the deadline, the resulting connection is closed instead of leaked.

To keep a persistent outage from accumulating an unbounded number of abandoned stuck threads (and potentially unclosable connections) -- e.g. across retries, many `fromQuery` channels, or long-running workflows -- outstanding abandoned attempts per datasource are capped at 16. Once the cap is reached, a new connect attempt fails immediately with an error explaining that previous attempts to the datasource are still stuck, instead of spawning another thread. A slot is released as soon as an abandoned attempt finally completes or dies, so the datasource recovers automatically once the outage clears.

If your driver exposes a native connect/socket timeout property (e.g. a `timeout`/`connectTimeout` entry in the JDBC URL or properties), you may still want to set it directly -- this change bounds the wait on the caller's side, but a driver-native setting can fail faster and more precisely for that driver's own transport.

Timing is computed with nanosecond precision throughout, so a sub-second configured timeout (e.g. `100ms`) isn't inflated by rounding.
