### PR TITLE
Cancel in-flight SQL query on workflow abort

### DIFF
--- a/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
+++ b/plugins/nf-sqldb/src/main/nextflow/sql/QueryHandler.groovy
@@ -72,6 +72,10 @@ class QueryHandler implements QueryOp<QueryHandler> {
     private long batchDelayMillis = 100
     private int queryCount
 
+    private final Object lock = new Object()
+    private Statement activeStatement
+    private boolean cancelRequested
+
     @Override
     QueryOp withStatement(String stm) {
         this.statement = stm
@@ -133,12 +137,77 @@ class QueryHandler implements QueryOp<QueryHandler> {
     }
 
     protected queryAsync(Connection conn) {
+        registerAbortHook()
         def future = CompletableFuture.runAsync ({ queryExec(conn) })
         future.exceptionally(this.&handlerException)
     }
 
-    static private void handlerException(Throwable e) {
+    private void registerAbortHook() {
+        final session = Global.session as Session
+        session?.onShutdown {
+            if( session.isAborted() )
+                cancel()
+        }
+    }
+
+    /**
+     * Cancel the statement currently executing this query, if any.
+     * Safe to call concurrently with query execution: if no statement
+     * is active yet, the cancellation is recorded and applied as soon
+     * as one is created. The actual driver {@code cancel()} call is made
+     * outside the lock so a stalling driver cannot block track/untrack,
+     * and any {@code SQLException} it raises (e.g. the statement was
+     * already closed by the time cancel runs) is logged, not propagated.
+     */
+    void cancel() {
+        Statement stm
+        synchronized (lock) {
+            cancelRequested = true
+            stm = activeStatement
+        }
+        if( stm == null )
+            return
+        try {
+            stm.cancel()
+        }
+        catch( java.sql.SQLException e ) {
+            log.debug "Unable to cancel in-flight SQL statement: ${e.message}"
+        }
+    }
+
+    private boolean isCancelled() {
+        synchronized (lock) {
+            return cancelRequested
+        }
+    }
+
+    /**
+     * Track the statement about to execute this query. Returns {@code true}
+     * if cancellation was already requested before the statement existed,
+     * in which case the caller must not execute it: a cancelled-but-idle
+     * JDBC statement is not guaranteed to interrupt a subsequent execute.
+     */
+    private boolean trackStatement(Statement stm) {
+        synchronized (lock) {
+            if( cancelRequested )
+                return true
+            activeStatement = stm
+            return false
+        }
+    }
+
+    private void untrackStatement() {
+        synchronized (lock) {
+            activeStatement = null
+        }
+    }
+
+    private void handlerException(Throwable e) {
         final error = e.cause ?: e
+        if( isCancelled() ) {
+            log.debug "SQL query cancelled: ${error.message}"
+            return
+        }
         log.error(error.message, error)
         final session = Global.session as Session
         session?.abort(error)
@@ -155,7 +224,12 @@ class QueryHandler implements QueryOp<QueryHandler> {
 
     protected void query0(Connection conn) {
         try {
-            try (Statement stm = conn.createStatement()) {
+            final Statement stm = conn.createStatement()
+            try {
+                if( trackStatement(stm) || isCancelled() ) {
+                    target.bind(Channel.STOP)
+                    return
+                }
                 final String normalizedStmt = normalize(statement)
                 // Execute the SQL query and get results
                 try (def rs = stm.executeQuery(normalizedStmt)) {
@@ -163,6 +237,10 @@ class QueryHandler implements QueryOp<QueryHandler> {
                         emitColumns(rs)
                     emitRowsAndClose(rs)
                 }
+            }
+            finally {
+                untrackStatement()
+                stm.close()
             }
         }
         finally {
@@ -175,26 +253,32 @@ class QueryHandler implements QueryOp<QueryHandler> {
             // create the query adding the `offset` and `limit` params
             final query = makePaginationStm(statement)
             // create the prepared statement
-            try (PreparedStatement stm = conn.prepareStatement(query)) {
-                int count = 0
-                int len = 0
-                do {
-                    final offset = (count++) * batchSize
-                    final limit = batchSize
+            final PreparedStatement stm = conn.prepareStatement(query)
+            try {
+                if( !trackStatement(stm) ) {
+                    int count = 0
+                    int len = 0
+                    while( count==0 || len==batchSize ) {
+                        final offset = (count++) * batchSize
+                        final limit = batchSize
 
-                    stm.setInt(1, limit)
-                    stm.setInt(2, offset)
-                    queryCount++
-                    try ( def rs = stm.executeQuery() ) {
-                        if( emitColumns && count==1 )
-                            emitColumns(rs)
-                        len = emitRows(rs)
-                        sleep(batchDelayMillis)
+                        stm.setInt(1, limit)
+                        stm.setInt(2, offset)
+                        if( isCancelled() )
+                            break
+                        queryCount++
+                        try ( def rs = stm.executeQuery() ) {
+                            if( emitColumns && count==1 )
+                                emitColumns(rs)
+                            len = emitRows(rs)
+                            sleep(batchDelayMillis)
+                        }
                     }
                 }
-                while( len==batchSize )
             }
             finally {
+                untrackStatement()
+                stm.close()
                 // close the channel
                 target.bind(Channel.STOP)
             }

--- a/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
+++ b/plugins/nf-sqldb/src/test/nextflow/sql/QueryHandlerTest.groovy
@@ -14,14 +14,18 @@
  * limitations under the License.
  *
  */
-
 package nextflow.sql
 
+
 import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 import groovy.sql.Sql
 import groovyx.gpars.dataflow.DataflowQueue
 import nextflow.Channel
+import nextflow.Global
+import nextflow.Session
 import nextflow.sql.config.SqlDataSource
 import spock.lang.Specification
 /**
@@ -188,5 +192,167 @@ class QueryHandlerTest extends Specification {
         result2.getVal() == ['ID', 'ALPHA']
         result2.getVal() == [1, 'Hello 1']
         result2.getVal() == [2, 'Hello 2']
+    }
+
+    def 'should cancel executing statement when the session aborts'() {
+        given: 'a statement that blocks until cancelled, simulating a long-running query'
+        def executing = new CountDownLatch(1)
+        def cancelledSignal = new CountDownLatch(1)
+        def cancelCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        def done = new CountDownLatch(1)
+        def statement = Mock(java.sql.Statement) {
+            executeQuery(_) >> {
+                executing.countDown()
+                cancelledSignal.await(5, TimeUnit.SECONDS)
+                throw new java.sql.SQLException('cancelled')
+            }
+            cancel() >> {
+                cancelCount.incrementAndGet()
+                cancelledSignal.countDown()
+            }
+        }
+        def conn = Mock(java.sql.Connection) {
+            createStatement() >> statement
+            close() >> { done.countDown() }
+        }
+        and: 'a handler wired to a live session, as it is when a workflow runs'
+        def session = new Session()
+        Global.setSession(session)
+        def handler = new QueryHandler() {
+            protected java.sql.Connection connect(SqlDataSource ds) { conn }
+        }
+        handler.withTarget(new DataflowQueue()).withStatement('select 1;')
+
+        when: 'the query starts executing asynchronously'
+        handler.perform(true)
+        and: 'it is actually in flight'
+        def reachedExecuting = executing.await(5, TimeUnit.SECONDS)
+        and: 'the session aborts, as nextflow does on workflow abort, and runs its shutdown hooks'
+        session.abort()
+        session.shutdown0()
+        and: 'the execution unwinds after being cancelled'
+        def reachedDone = done.await(5, TimeUnit.SECONDS)
+
+        then: 'the query actually reached in-flight execution before abort'
+        reachedExecuting
+        and: 'the connection was actually closed, proving the async task unwound'
+        reachedDone
+        and: 'the in-flight statement was cancelled exactly once'
+        cancelCount.get() == 1
+
+        cleanup:
+        Global.setSession(null)
+    }
+
+    def 'should ignore a late cancel after the query has completed normally'() {
+        given: 'a statement whose query returns no rows'
+        def cancelCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        def resultSetMeta = Mock(java.sql.ResultSetMetaData) { getColumnCount() >> 0 }
+        def resultSet = Mock(java.sql.ResultSet) { next() >> false; getMetaData() >> resultSetMeta }
+        def statement = Mock(java.sql.Statement) {
+            executeQuery(_) >> resultSet
+            cancel() >> { cancelCount.incrementAndGet() }
+        }
+        def conn = Mock(java.sql.Connection) { createStatement() >> statement }
+        def handler = new QueryHandler() {
+            protected java.sql.Connection connect(SqlDataSource ds) { conn }
+        }
+        handler.withTarget(new DataflowQueue()).withStatement('select 1;')
+
+        when: 'the query runs to completion'
+        handler.perform()
+        and: 'the workflow aborts afterwards'
+        handler.cancel()
+
+        then: 'the already-completed statement is never touched'
+        cancelCount.get() == 0
+    }
+
+    def 'should never execute a statement whose query was cancelled before it existed'() {
+        given: 'a statement that must not be executed once cancelled up front'
+        def statement = Mock(java.sql.Statement) {
+            0 * executeQuery(_)
+        }
+        def conn = Mock(java.sql.Connection) { createStatement() >> statement }
+        def target = new DataflowQueue()
+        def handler = new QueryHandler() {
+            protected java.sql.Connection connect(SqlDataSource ds) { conn }
+        }
+        handler.withTarget(target).withStatement('select 1;')
+        and: 'the query is cancelled before it starts, e.g. an abort racing the query creation'
+        handler.cancel()
+
+        when:
+        handler.perform()
+
+        then: 'the statement is never executed and the channel still terminates'
+        target.getVal() == Channel.STOP
+    }
+
+    def 'should stop a paginated query mid-batch when cancelled between pages'() {
+        given: 'a batched query that is cancelled while consuming the first page, before the second page is fetched'
+        def cancelCount = new java.util.concurrent.atomic.AtomicInteger(0)
+        def executedPages = new java.util.concurrent.atomic.AtomicInteger(0)
+        def handler
+        def resultSetMeta = Mock(java.sql.ResultSetMetaData) { getColumnCount() >> 1 }
+        def fullResultSet = Mock(java.sql.ResultSet) {
+            getMetaData() >> resultSetMeta
+            next() >> true >> true >> true >> false
+            getObject(1) >> 'a' >> 'b' >> {
+                // cancel arrives while the statement is idle, in between rows of the current page -
+                // it must stop the pagination loop even though the statement isn't executing a command
+                handler.cancel()
+                'c'
+            }
+        }
+        def statement = Mock(java.sql.PreparedStatement) {
+            executeQuery() >> {
+                executedPages.incrementAndGet()
+                fullResultSet
+            }
+            cancel() >> { cancelCount.incrementAndGet() }
+        }
+        def conn = Mock(java.sql.Connection) { prepareStatement(_) >> statement }
+        def target = new DataflowQueue()
+        handler = new QueryHandler() {
+            protected java.sql.Connection connect(SqlDataSource ds) { conn }
+        }
+        handler.withTarget(target).withStatement('select 1').withOpts(batchSize: 3, batchDelay: 0)
+
+        when:
+        handler.perform()
+
+        then: 'only the first page executes; the loop checks cancellation before fetching the next one'
+        executedPages.get() == 1
+        and: 'the cancel request reached the tracked statement'
+        cancelCount.get() == 1
+        and: 'the channel is still terminated after the (partial) page rows'
+        target.getVal() == ['a']
+        target.getVal() == ['b']
+        target.getVal() == ['c']
+        target.getVal() == Channel.STOP
+    }
+
+    def 'should never execute a paginated query page when cancelled during page setup'() {
+        given: 'a statement cancelled while binding params for the first page, before executeQuery runs'
+        def handler
+        def statement = Mock(java.sql.PreparedStatement) {
+            setInt(2, 0) >> { handler.cancel() }
+            0 * executeQuery()
+        }
+        def conn = Mock(java.sql.Connection) {
+            prepareStatement(_) >> statement
+        }
+        def target = new DataflowQueue()
+        handler = new QueryHandler() {
+            protected java.sql.Connection connect(SqlDataSource ds) { conn }
+        }
+        handler.withTarget(target).withStatement('select 1').withOpts(batchSize: 3, batchDelay: 0)
+
+        when:
+        handler.perform()
+
+        then: 'the page is never executed and the channel still terminates'
+        target.getVal() == Channel.STOP
     }
 }


### PR DESCRIPTION
When a workflow aborts while a `fromQuery` statement is executing, the JDBC statement kept running to completion in the background instead of being interrupted. This left long-running queries occupying DB connections/resources after Nextflow had already decided to stop.

`QueryHandler` now tracks the `Statement` currently executing a query and cancels it when the session aborts. Tracking is synchronized (driver `cancel()` runs outside the lock, with `SQLException` caught and logged rather than propagated), a cancel requested before the statement exists is still honored (the statement is never executed rather than cancelling an idle one), and the paginated (`batchSize`) path re-checks cancellation on every page, not just once before the loop starts.

Scoped to canceling a statement that already exists for `fromQuery`; it does not touch connection establishment, and `sqlInsert` (`InsertHandler`) is untouched since it uses a different per-record execution model with no async task to cancel.
